### PR TITLE
ajusted battery code slightly for more accurate battery reading

### DIFF
--- a/source/shared/battery_utils.cpp
+++ b/source/shared/battery_utils.cpp
@@ -11,7 +11,7 @@ const char *GetApproxPercentLabel(u8 level)
 {
   switch (level)
   {
-  case 0: return "~0%";
+  case 0: return "~1%";
   case 1: return "~20%";
   case 2: return "~40%";
   case 3: return "~60%";


### PR DESCRIPTION
if the battery was inbetween 10 and 0, instead of showing 0% as the battery, show 1%.
because if the console is at 0, the batterys dead!